### PR TITLE
Add .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/workspace.xml
-/.idea/libraries
+/.idea
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
Adding .idea directory to gitignore since it's an IntelliJ-specific thing and contents may differ between developers. We can always re-add it later if it turns out to have facilitated consistent project setup.